### PR TITLE
Replace github.copilot-nightly VS code extension with github.copilot

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -15,6 +15,6 @@
             - streetsidesoftware.code-spell-checker
             - ms-python.python
             - DEVSENSE.phptools-vscode
-            - GitHub.copilot-nightly
+            - GitHub.copilot
             - snyk-security.snyk-vulnerability-scanner
 


### PR DESCRIPTION
VScode marketplace had dropped a nightly build (and is no longer accessible), therefore github.copilot needs to be installed instead. 

P.S. Thank you for this playbook. :) 