### PR TITLE
Fix evil-winrm net being found in PATH

### DIFF
--- a/roles/install-tools/tasks/gem-tools.yml
+++ b/roles/install-tools/tasks/gem-tools.yml
@@ -1,8 +1,6 @@
 ---
 - name: "Installing tools from Gems"
-  gem:
-    name: "{{ item }}"
-    state: latest
+  shell: "gem install {{ item }}"
   loop:
     - logger
     - stringio


### PR DESCRIPTION
The issue is that the ansible gem module seems to install gems differently than the default parrot gem installer (parrot gem seems to copy winrm into /usr/local/bin/ which is in PATH by default).

I solved it by running the parrot gem installer with shell instead of using the ansible module but this may not be the best way to solve it.