### PR TITLE
Fix gem install path

### DIFF
--- a/roles/install-tools/tasks/gem-tools.yml
+++ b/roles/install-tools/tasks/gem-tools.yml
@@ -3,6 +3,7 @@
   gem:
     name: "{{ item }}"
     state: latest
+    user_install: false
   loop:
     - logger
     - stringio


### PR DESCRIPTION
Setting `user_install` to `false` makes the Gems install to `/usr/local/bin` instead of root's home.