### PR TITLE
Update extract_tar() to fix exception on .tar.gz files

### DIFF
--- a/roles/install-tools/files/githubdownload.py
+++ b/roles/install-tools/files/githubdownload.py
@@ -79,14 +79,13 @@ def extract_tar(compressed_data, out_file):
     Returns: Nothing
     """
     try:
-        gzip_header = compressed_data.getvalue()[:10]
-        if gzip_header.startswith(b"\x1f\x8b"):
-            with gzip.open(compressed_data, "rb") as gz:
-                with tarfile.open(fileobj=gz, mode="r:gz") as tar:
-                    tar.extractall(path=out_file)    
-                    return
-        else:
-            raise Exception("Unable to identify compression type")
+      gzip_header = compressed_data.getvalue()[:10]
+      if gzip_header.startswith(b"\x1f\x8b"):
+        tar = tarfile.open(fileobj=compressed_data)
+        tar.extractall(path=out_file)
+        return
+      else:
+          raise Exception("Unable to identify compression type")
     except Exception as e:
         raise Exception(e)
 


### PR DESCRIPTION
Fix the "not a gzip file" exception that is thrown when trying to extract a .tar.gz release. closes #18 



