### PR TITLE
Using \t and prettify

### DIFF
--- a/roles/configure-system/tasks/configure-sudoers.yml
+++ b/roles/configure-system/tasks/configure-sudoers.yml
@@ -1,9 +1,12 @@
 ---
-- name: Add sudoers rule for the current user
+- name: Add NOPASSWD rule for the current user
   become: true
   lineinfile:
     dest: /etc/sudoers
+    insertbefore: EOF
     regexp: "{{ ansible_user_id }} ALL="
-    line: "{{ ansible_user_id }} ALL=(ALL) NOPASSWD: ALL"
+    line: "{{ item }}"
     validate: visudo -cf %s
   when: ansible_user_id != 'root'
+  with_items:
+    - "{{ ansible_user_id }}\tALL=(ALL) NOPASSWD:ALL"


### PR DESCRIPTION
When already assigned a user manually for NOPASSWD and running the playbook, it adds instead of ignores because of spaces used in the current/older version if the task.
Now using tab, this will not again add the user on a new line but ignores when properly configured with tabs, just like 
root    ALL=(ALL:ALL) ALL
has a tab instead of spaces, so it's more natively.

Just some minor approvements. Thanks, you rock ippsec.