### PR TITLE
added allowance to break system packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Instructions
 * Start with Parrot HTB Edition
-* Install Ansible (python3 -m pip install ansible)
+* Install Ansible (`python3 -m pip install ansible --break-system-packages`)
 * Clone and enter the repo (git clone)
 * ansible-galaxy install -r requirements.yml
 * Make sure we have a sudo token (sudo whoami)


### PR DESCRIPTION
on newest python3 version, there is an "error" installing ansible using pip, as it can break system packages. it can be overriden by using --break-system-packages parameter.