### PR TITLE
Updated README.md & fixed ansible.builtin.include..

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Instructions
 * Start with Parrot HTB Edition
-* Install Ansible (python3 -m pip install ansible)
+* Install Ansible (python3 -m pip install ansible --break-system-packages)
 * Clone and enter the repo (git clone)
 * ansible-galaxy install -r requirements.yml
 * Make sure we have a sudo token (sudo whoami)

--- a/roles/configure-logging/tasks/main.yml
+++ b/roles/configure-logging/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
-- include: "ufw.yml"
-- include: "auditd.yml"
+- include_tasks: "ufw.yml"
+- include_tasks: "auditd.yml"

--- a/roles/configure-system/tasks/main.yml
+++ b/roles/configure-system/tasks/main.yml
@@ -1,2 +1,2 @@
 ---
-- include: "configure-sudoers.yml"
+- include_tasks: "configure-sudoers.yml"

--- a/roles/customize-browser/tasks/main.yml
+++ b/roles/customize-browser/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
-- include: "burp.yml"
-- include: "firefox.yml"
+- include_tasks: "burp.yml"
+- include_tasks: "firefox.yml"

--- a/roles/install-tools/tasks/main.yml
+++ b/roles/install-tools/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
-- include: apt-stuff.yml
-- include: kerbrute.yml
-- include: github-repos.yml
-- include: python-tools.yml
-- include: gem-tools.yml
+- include_tasks: apt-stuff.yml
+- include_tasks: kerbrute.yml
+- include_tasks: github-repos.yml
+- include_tasks: python-tools.yml
+- include_tasks: gem-tools.yml


### PR DESCRIPTION
I've updated the README:
Latest Debian releases will no longer allow `pip install` outside of a venv:
You can still force it via `pip install --break-system-packages` if needed.

> ERROR! [DEPRECATED]: ansible.builtin.include has been removed. This feature was removed from ansible-core in a release after 2023-05-16. Please update your playbooks.

Replaced `include` with `include_tasks`..

First grep it:
```
➜ grep -HRn ' include:' *                           
roles/install-tools/tasks/main.yml:2:- include: apt-stuff.yml
roles/install-tools/tasks/main.yml:3:- include: kerbrute.yml
roles/install-tools/tasks/main.yml:4:- include: github-repos.yml
roles/install-tools/tasks/main.yml:5:- include: python-tools.yml
roles/install-tools/tasks/main.yml:6:- include: gem-tools.yml
roles/configure-system/tasks/main.yml:2:- include: "configure-sudoers.yml"
roles/customize-browser/tasks/main.yml:2:- include: "burp.yml"
roles/customize-browser/tasks/main.yml:3:- include: "firefox.yml"
roles/configure-logging/tasks/main.yml:2:- include: "ufw.yml"
roles/configure-logging/tasks/main.yml:3:- include: "auditd.yml"
```

Manually, you can replace it with:
```
➜ sed -i 's/include/include_tasks/g' roles/*/tasks/*.yml
```

