### PR TITLE
Modified code to solve errors in latest version of ansible

### DIFF
--- a/roles/configure-logging/files/audit.rules
+++ b/roles/configure-logging/files/audit.rules
@@ -674,7 +674,7 @@
 -w /usr/bin/kubelet -k kubelet
 
 # ipc system call
-# /usr/include/linux/ipc.h
+# /usr/include_tasks/linux/ipc.h
 
 ## msgctl
 #-a always,exit -S ipc -F a0=14 -k T1559_Inter-Process_Communication

--- a/roles/configure-logging/files/laurel/config.toml
+++ b/roles/configure-logging/files/laurel/config.toml
@@ -3,7 +3,7 @@ directory = "/var/log/laurel"
 # Drop privileges from root to this user
 user = "_laurel"
 # The periodical time window in seconds for status information to be printed to Syslog.
-# Status report includes the running version, config and parsing stats.
+# Status report include_taskss the running version, config and parsing stats.
 # Default is 0 --> no status reports.
 statusreport-period = 0
 # By default, audit events are read from stdin ("stdin"). Alternatively, they

--- a/roles/configure-logging/tasks/main.yml
+++ b/roles/configure-logging/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
-- include: "ufw.yml"
-- include: "auditd.yml"
+- include_tasks: "ufw.yml"
+- include_tasks: "auditd.yml"

--- a/roles/configure-system/tasks/main.yml
+++ b/roles/configure-system/tasks/main.yml
@@ -1,2 +1,2 @@
 ---
-- include: "configure-sudoers.yml"
+- include_tasks: "configure-sudoers.yml"

--- a/roles/customize-browser/tasks/main.yml
+++ b/roles/customize-browser/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
-- include: "burp.yml"
-- include: "firefox.yml"
+- include_tasks: "burp.yml"
+- include_tasks: "firefox.yml"

--- a/roles/install-tools/tasks/main.yml
+++ b/roles/install-tools/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
-- include: apt-stuff.yml
-- include: kerbrute.yml
-- include: github-repos.yml
-- include: python-tools.yml
-- include: gem-tools.yml
+- include_tasks: apt-stuff.yml
+- include_tasks: kerbrute.yml
+- include_tasks: github-repos.yml
+- include_tasks: python-tools.yml
+- include_tasks: gem-tools.yml


### PR DESCRIPTION
In the latest version ansible  ansible.builtin.include has been removed. we can use include_tasks or import_tasks instead. This feature was removed from ansible-core in a release after 2023-05-16.