### PR TITLE
Fix build failure on Parrot HTB 6.3

### DIFF
--- a/roles/configure-logging/tasks/main.yml
+++ b/roles/configure-logging/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
-- include: "ufw.yml"
-- include: "auditd.yml"
+- include_tasks: "ufw.yml"
+- include_tasks: "auditd.yml"

--- a/roles/configure-system/tasks/main.yml
+++ b/roles/configure-system/tasks/main.yml
@@ -1,2 +1,2 @@
 ---
-- include: "configure-sudoers.yml"
+- include_tasks: "configure-sudoers.yml"

--- a/roles/customize-browser/tasks/main.yml
+++ b/roles/customize-browser/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
-- include: "burp.yml"
-- include: "firefox.yml"
+- include_tasks: "burp.yml"
+- include_tasks: "firefox.yml"

--- a/roles/install-tools/tasks/apt-stuff.yml
+++ b/roles/install-tools/tasks/apt-stuff.yml
@@ -17,6 +17,7 @@
       - ntpdate
       - flameshot
       - exiftool
+      - rsyslog
     state: latest
   become: true
   become_method: sudo

--- a/roles/install-tools/tasks/main.yml
+++ b/roles/install-tools/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
-- include: apt-stuff.yml
-- include: kerbrute.yml
-- include: github-repos.yml
-- include: python-tools.yml
-- include: gem-tools.yml
+- include_tasks: apt-stuff.yml
+- include_tasks: kerbrute.yml
+- include_tasks: github-repos.yml
+- include_tasks: python-tools.yml
+- include_tasks: gem-tools.yml


### PR DESCRIPTION
On a fresh install of a newer Parrot HTB Edition than these scripts were originally meant for, an attempt to run them using Ansible produces the following output:

```
┌─[htb-ac-1424625@kennystrawnmusic-pwnaegisr2]─[~/parrot-build]
└──╼ $ansible-playbook main.yml
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that
the implicit localhost does not match 'all'
ERROR! this task 'include' has extra params, which is only allowed in the following modules: include_role, set_fact, script, command, group_by, raw, import_role, import_tasks, shell, add_host, win_command, include_vars, include_tasks, meta, win_shell

The error appears to be in '/home/htb-ac-1424625/parrot-build/roles/customize-browser/tasks/main.yml': line 2, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

---
- include: "burp.yml"
  ^ here

```

In addition, rsyslog isn't bundled with these newer versions either, so I had to add it to `apt-stuff.yml` for the enabling of rsyslog to work as well. This pull request, therefore, should fix both of these issues.