### PR TITLE
Fix playbook for Parrot 7.5 HTB (Debian 13 / trixie)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
-** Make sure to pip install ansible, apt has an older copy **
+** Install Ansible with pipx. On Parrot 7.5+ (Debian 13) a system pip install fails with PEP 668 (externally-managed), and apt ships an older copy. **
 
 # Instructions
 * Start with Parrot HTB Edition
-* Install Ansible (python3 -m pip install ansible)
+* Install Ansible with pipx:
+  * `sudo apt install -y pipx`
+  * `pipx install --include-deps ansible`
+  * `pipx ensurepath` (then open a new shell)
+  * `pipx inject ansible pipx` (the playbook's pipx tasks run via Ansible's own interpreter, which needs the pipx module)
 * Clone and enter the repo (git clone)
 * ansible-galaxy install -r requirements.yml
-* Make sure we have a sudo token (sudo whoami)
+* Make sure we have a sudo token (sudo whoami) — or run the playbook with `-K`
 * ansible-playbook main.yml
 
 # Off-Video Changes

--- a/main.yml
+++ b/main.yml
@@ -2,6 +2,8 @@
 - name: "Customizing Parrot"
   hosts: localhost
   connection: local
+  environment:
+    NODE_NO_WARNINGS: "1"
   roles:
     - role: "roles/install-tools"
     - role: "roles/configure-tmux"
@@ -11,7 +13,7 @@
     - role: "roles/configure-system"
     - role: gantsign.visual-studio-code
       users:
-        - username: "{{ ansible_user_id }}" 
+        - username: "{{ ansible_user_id }}"
           visual_studio_code_extensions:
             - streetsidesoftware.code-spell-checker
             - ms-python.python

--- a/roles/install-tools/defaults/main.yml
+++ b/roles/install-tools/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # defaults file for configure-logging
-distribution: "bookworm"
+distribution: "trixie"

--- a/roles/install-tools/tasks/apt-stuff.yml
+++ b/roles/install-tools/tasks/apt-stuff.yml
@@ -55,16 +55,25 @@
   become: true
   become_method: sudo
 
-- name: "Add Docker keyring to apt"
-  apt_key:
+- name: "Create apt keyrings directory"
+  file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: "0755"
+  become: true
+  become_method: sudo
+
+- name: "Add Docker GPG key"
+  get_url:
     url: "https://download.docker.com/linux/debian/gpg"
-    state: present
+    dest: /etc/apt/keyrings/docker.asc
+    mode: "0644"
   become: true
   become_method: sudo
 
 - name: "Install Docker Repository"
   apt_repository:
-    repo: "deb [arch=amd64] https://download.docker.com/linux/debian {{ distribution }} stable"
+    repo: "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian {{ distribution }} stable"
     state: present
     update_cache: yes
   become: true


### PR DESCRIPTION
IppSec's parrot-build predates Debian 13, so it breaks on the current Parrot 7.5 HTB edition (`echo` = Debian 13 / trixie, Python 3.13). This PR gets a clean, idempotent run on that edition (verified `failed=0`).

### Fixes
- **Ansible install (README):** `python3 -m pip install ansible` now fails under PEP 668 (`externally-managed-environment`). Switched the instructions to pipx.
- **`pipx inject ansible pipx`:** `roles/install-tools/tasks/python-tools.yml` uses `community.general.pipx`, which shells out to `python -m pipx` via Ansible's *own* interpreter. When Ansible is installed with pipx, that venv lacks the pipx module (`No module named pipx`), so the injection is required.
- **Docker repo:** `roles/install-tools/tasks/apt-stuff.yml` used the `apt_key` module, but the `apt-key` binary was removed in trixie. Replaced with the keyring-file method (`/etc/apt/keyrings/docker.asc` + `signed-by=`), which is also the method Docker currently recommends.
- **`distribution`:** `roles/install-tools/defaults/main.yml` defaulted to `bookworm`; bumped to `trixie` to match the current edition's Debian base (Docker's trixie repo is live).
- **VS Code extensions idempotency:** set `NODE_NO_WARNINGS=1` at the play level in `main.yml`. The gantsign role's module fails on any non-empty stderr unless it contains the old `[DEP0005]` warning; current VS Code's `code` CLI emits `[DEP0169] url.parse() DeprecationWarning` to stderr, so the "Install extensions" task fails on every run even though the extensions install fine. Emptying stderr makes the task idempotent.

### Heads-up, not included in this PR
The VS Code `GitHub.copilot` extension now fails on current builds — VS Code ships Copilot Chat as a built-in extension and the gantsign role errors trying to downgrade it (`cannot be downgraded`). Removing `GitHub.copilot` from the extension list in `main.yml` resolves it. Left out here since it touches the intended extension set — flagging for your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
